### PR TITLE
fix: load correct updater when config-rule command line is invoked

### DIFF
--- a/aws_cfn_update/cli.py
+++ b/aws_cfn_update/cli.py
@@ -119,7 +119,7 @@ def lambda_body(ctx, resource, file, path):
 @click.argument('path', nargs=-1, required=True, type=click.Path(exists=True))
 @click.pass_context
 def config_rule_body(ctx, resource, file, path):
-    updater = LambdaInlineCodeUpdater()
+    updater = ConfigRuleInlineCodeUpdater()
 
     with open(file, 'r') as f:
         body = f.read()

--- a/aws_cfn_update/config_rule_inline_code_updater.py
+++ b/aws_cfn_update/config_rule_inline_code_updater.py
@@ -47,7 +47,7 @@ class ConfigRuleInlineCodeUpdater(CfnUpdater):
 
     def update_template(self):
         """
-        updates the Code property of a AWS::Lambda::Function resource of name `self.resource` to `self.code`
+        updates the Code property of a AWS::Config::ConfigRule resource of name `self.resource` to `self.code`
         """
         resource = self.template.get('Resources', {}).get(self.resource, None)
         if resource and resource['Type'] == 'AWS::Config::ConfigRule':
@@ -70,7 +70,7 @@ class ConfigRuleInlineCodeUpdater(CfnUpdater):
                 self.dirty = True
         elif resource:
             sys.stderr.write(
-                'WARN: resource {} in {} is not of type AWS::Lambda::Function\n'.format(self.resource, self.filename))
+                'WARN: resource {} in {} is not of type AWS::Config::ConfigRule\n'.format(self.resource, self.filename))
 
     def main(self, resource, code, paths, dry_run, verbose):
         self.resource = resource


### PR DESCRIPTION
Previously the Lambda updater was loaded when the config rule command was invoked.