### PR TITLE
fix: preserve policy details on policy replacement

### DIFF
--- a/aws_cfn_update/config_rule_inline_code_updater.py
+++ b/aws_cfn_update/config_rule_inline_code_updater.py
@@ -66,7 +66,7 @@ class ConfigRuleInlineCodeUpdater(CfnUpdater):
                 if 'CustomPolicyDetails' not in resource['Properties']['Source']:
                     resource['Properties']['Source']['CustomPolicyDetails'] = {}
 
-                resource['Properties']['Source']['CustomPolicyDetails'] = {'PolicyText': PreservedScalarString(self.code)}
+                resource['Properties']['Source']['CustomPolicyDetails']['PolicyText'] = PreservedScalarString(self.code)
                 self.dirty = True
         elif resource:
             sys.stderr.write(

--- a/tests/test_config_rule_inline_code_updater.py
+++ b/tests/test_config_rule_inline_code_updater.py
@@ -4,10 +4,24 @@ from aws_cfn_update.config_rule_inline_code_updater import (
 import json
 
 
-sample = {"Resources": {"ConfigRule": {"Type": "AWS::Config::ConfigRule"}}}
 
+sample = {
+    "Resources": {
+        "ConfigRule": {
+            "Type": "AWS::Config::ConfigRule",
+            "Properties": {
+                "Source": {
+                    "CustomPolicyDetails": {
+                        "EnableDebugLogDelivery": "true",
+                        "PolicyRuntime": "guard-2.x.x"
+                    }
+                }
+            }
+        }
+    }
+}
 
-def test_replace_body():
+def test_add_body():
     updater = Updater()
     updater.resource = "ConfigRule"
     updater.code = 'let buckets = Resources.*[ Type == "AWS::S3::Bucket" ]'
@@ -18,22 +32,42 @@ def test_replace_body():
     assert "Properties" in updater.template["Resources"]["ConfigRule"]
 
     assert "Source" in updater.template["Resources"]["ConfigRule"]["Properties"]
+    source = updater.template["Resources"]["ConfigRule"]["Properties"]["Source"]
     assert (
         "CustomPolicyDetails"
-        in updater.template["Resources"]["ConfigRule"]["Properties"]["Source"]
-    )
-    assert (
-        "PolicyText"
-        in updater.template["Resources"]["ConfigRule"]["Properties"]["Source"][
-            "CustomPolicyDetails"
-        ]
+        in source
     )
 
+    assert ("true" == source["CustomPolicyDetails"]["EnableDebugLogDelivery"])
+    assert ("guard-2.x.x" in source["CustomPolicyDetails"]["PolicyRuntime"])
+
     assert (
-        updater.template["Resources"]["ConfigRule"]["Properties"]["Source"][
-            "CustomPolicyDetails"
-        ]["PolicyText"]
-        == 'let buckets = Resources.*[ Type == "AWS::S3::Bucket" ]'
+        source["CustomPolicyDetails"]["PolicyText"] == 'let buckets = Resources.*[ Type == "AWS::S3::Bucket" ]'
+    )
+
+def test_replace_body():
+    updater = Updater()
+    updater.resource = "ConfigRule"
+    updater.code = 'let buckets = Resources.*[ Type == "AWS::S3::Bucket" ]'
+    updater.template = sample.copy()
+    updater.template["Resources"]["ConfigRule"]["Properties"]["Source"]["CustomPolicyDetails"]["PolicyText"] = "Existing Policy"
+
+    updater.update_template()
+    assert updater.dirty
+    assert "Properties" in updater.template["Resources"]["ConfigRule"]
+
+    assert "Source" in updater.template["Resources"]["ConfigRule"]["Properties"]
+    source = updater.template["Resources"]["ConfigRule"]["Properties"]["Source"]
+    assert (
+        "CustomPolicyDetails"
+        in source
+    )
+
+    assert ("true" == source["CustomPolicyDetails"]["EnableDebugLogDelivery"])
+    assert ("guard-2.x.x" in source["CustomPolicyDetails"]["PolicyRuntime"])
+
+    assert (
+        source["CustomPolicyDetails"]["PolicyText"] == 'let buckets = Resources.*[ Type == "AWS::S3::Bucket" ]'
     )
 
 


### PR DESCRIPTION
When the `PolicyText` is replaced we also replaced the polikcy details like `PolicyRuntime` which is mandatory for deployments. By adding additional unit tests we guarantee that the `PolicyRuntime` is never overwritten.