### PR TITLE
fix: do not insert the owner on property level

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,8 +307,12 @@ into:
 # config-rule-inline-code - updates the inline code of an AWS::Config::ConfigRule resource.
 
 Update the inline code of an AWS::Config::ConfigRule to include the content of the
-specified file. It changes:
+specified file. When executing:
 
+```shell
+aws-cfn-update config-rule-inline-code --resource ConfigRule --file ./rules/my-rule.guard template.yaml
+```
+It changes:
 ```
     ConfigRule:
       Type: AWS::Config::ConfigRule
@@ -322,18 +326,18 @@ specified file. It changes:
 into:
 ```
     ConfigRule:
-        Type: AWS::Config::ConfigRule
-        Properties:
-          Source:
-            Owner: CUSTOM_POLICY
-            CustomPolicyDetails:
-              EnableDebugLogDelivery: true
-              PolicyRuntime: guard-2.x.x
-              PolicyText: |-
-                rule name when resourceType == "AWS::S3::Bucket" {
-                    ...
-                }
-              ...
+      Type: AWS::Config::ConfigRule
+      Properties:
+        Source:
+          Owner: CUSTOM_POLICY
+          CustomPolicyDetails:
+            EnableDebugLogDelivery: true
+            PolicyRuntime: guard-2.x.x
+            PolicyText: |
+              rule name when resourceType == "AWS::S3::Bucket" {
+                  ...
+              }
+            ...
 ```
 
 # state-machine-definition - updates the definition string of an AWS::StepFunctions::StateMachine

--- a/src/aws_cfn_update/config_rule_inline_code_updater.py
+++ b/src/aws_cfn_update/config_rule_inline_code_updater.py
@@ -24,6 +24,9 @@ class ConfigRuleInlineCodeUpdater(CfnUpdater):
 \b
   ConfigRule:
     Type: AWS::Config::ConfigRule
+    Properties:
+      Source:
+        Owner: CUSTOM_POLICY
 
 \b
   ConfigRule:
@@ -52,12 +55,12 @@ class ConfigRuleInlineCodeUpdater(CfnUpdater):
         updates the Code property of a AWS::Config::ConfigRule resource of name `self.resource` to `self.code`
         """
         resource = self.template.get('Resources', {}).get(self.resource_name, None)
+        properties = resource.get('Properties', {})
         if (
                 resource
                 and resource["Type"] == "AWS::Config::ConfigRule"
-                and resource.get("Owner", "CUSTOM_POLICY") == "CUSTOM_POLICY"
+                and properties.get("Source", {}).get("Owner") == "CUSTOM_POLICY"
         ):
-            properties = resource.get('Properties', {})
             source = properties.get('Source', {})
             details = source.get('CustomPolicyDetails', {})
             old_code = details.get('PolicyText', None)
@@ -67,8 +70,6 @@ class ConfigRuleInlineCodeUpdater(CfnUpdater):
                     'INFO: updating policy text of config rule {} in {}\n'.format(self.resource_name, self.filename))
                 if 'Properties' not in resource:
                     resource['Properties'] = {}
-                if 'Owner' not in resource['Properties']:
-                    resource['Properties']['Owner'] = 'CUSTOM_POLICY'
                 if 'Source' not in resource['Properties']:
                     resource['Properties']['Source'] = {}
                 if 'CustomPolicyDetails' not in resource['Properties']['Source']:

--- a/tests/test_config_rule_inline_code_updater.py
+++ b/tests/test_config_rule_inline_code_updater.py
@@ -11,6 +11,7 @@ sample = {
             "Type": "AWS::Config::ConfigRule",
             "Properties": {
                 "Source": {
+                    "Owner": "CUSTOM_POLICY",
                     "CustomPolicyDetails": {
                         "EnableDebugLogDelivery": "true",
                         "PolicyRuntime": "guard-2.x.x"
@@ -38,6 +39,7 @@ def test_add_body():
         in source
     )
 
+    assert ("CUSTOM_POLICY" == source["Owner"])
     assert ("true" == source["CustomPolicyDetails"]["EnableDebugLogDelivery"])
     assert ("guard-2.x.x" in source["CustomPolicyDetails"]["PolicyRuntime"])
 
@@ -63,6 +65,7 @@ def test_replace_body():
         in source
     )
 
+    assert ("CUSTOM_POLICY" == source["Owner"])
     assert ("true" == source["CustomPolicyDetails"]["EnableDebugLogDelivery"])
     assert ("guard-2.x.x" in source["CustomPolicyDetails"]["PolicyRuntime"])
 


### PR DESCRIPTION
The owner of the rule was checked on the incorrect level. By fixing the level and not adding it to the properties we can actually deploy the template once the code has been replaced.